### PR TITLE
Add 2022 and 2023 (prep for 2024)

### DIFF
--- a/lib/models/ranktype.dart
+++ b/lib/models/ranktype.dart
@@ -21,6 +21,8 @@ enum RankType {
   Year2019,
   Year2020,
   Year2021,
+  Year2022,
+  Year2023,
   Last12months,
   Last6months,
   Last3months,
@@ -79,6 +81,10 @@ String getType({
       return 'Year 2020';
     case RankType.Year2021:
       return 'Year 2021';
+    case RankType.Year2022:
+      return 'Year 2022';
+    case RankType.Year2023:
+      return 'Year 2023';
     case RankType.Last12months:
       return 'Last 12 months';
     case RankType.Last6months:


### PR DESCRIPTION
There's no point in merging until 2024. This adds the data spans for 2022 and 2023 (which will be there in 2024).